### PR TITLE
feat: Add usePreviewPath option on redirects to keep site preview path on redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ variable will need to be updated in the `manifest.yml`.
 
 To support short-term site redirects, the proxy uses an included redirects config which is built during deployment via a credhub json credential named `proxy-<env>-site-redirects` and set as an environment variable as `SITE_REDIRECTS`. The site redirects value is an array of objects with the following structure:
 
-|Key|Required?|Description|
---- | --- | --- |
-|`subdomain`|:white_check_mark|The site's Pages subdomain|
-|`target|:white_check_mark|The target domain for the redirect|
-|`path`|:x|An optional path appended to the redirect target|
+|Key|Required?|Default|Description|
+--- | --- | --- | --- |
+|`subdomain`|:white_check_mark:|__N/A__|The site's Pages subdomain|
+|`target`|:white_check_mark:|__N/A__|The target domain for the redirect|
+|`path`|:x:|`''`|An optional path appended to the redirect target|
+|`usePreviewPath`|:x:|`false`|An optional boolean to append the site's preview path to redirect target|
 
 ## Local setup
 ### Install Depedencies

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -30,15 +30,16 @@ function cleanPath(path) {
 }
 
 function createRedirect(redirect) {
-  const { subdomain, path, target } = redirect;
+  const { subdomain, path, target, usePreviewPath } = redirect;
 
   if (!subdomain) throw 'Subdomain must be defined for redirect.'
   if (!target) throw 'Target must be defined for redirect.'
 
+  const requestPath = usePreviewPath ? '$request_uri' : '$remaining_path';
   const toPath = cleanPath(path);
 
   return `if ($name = "${subdomain}") {
-  return 301 "https://${target}${toPath}$request_uri";
+  return 301 "https://${target}${toPath}${requestPath}";
 }\n
 `;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -82,6 +82,10 @@ http {
     add_header X-Server "Cloud.gov Pages" always;
     add_header X-Robots-Tag $robot_header always;
 
+    if ($request_uri ~ "^/((site|preview|demo))/(([^/]+))/(([^/]+))(?<remaining>(.*))$" ) {
+        set  $remaining_path  $remaining;
+    }
+
     include redirects.conf;
 
     location =/health {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -54,18 +54,21 @@ function getFixtures(bucketType) {
   };
 };
 
-function createRedirect(subdomain, target, path) {
+function createRedirect(subdomain, target, { path, usePreviewPath = false} = {}) {
   return {
     subdomain,
     target,
     ...(path && { path }),
+    ...(usePreviewPath && { usePreviewPath })
   };
 }
 
 const redirects = [
   createRedirect('subdomain1', 'target.one'),
-  createRedirect('subdomain2', 'target.two', 'targettwopath'),
-  createRedirect('subdomain3', 'target.three', 'target/three/path'),
+  createRedirect('subdomain2', 'target.two', { path: 'targettwopath' }),
+  createRedirect('subdomain3', 'target.three', {
+    usePreviewPath: true,
+  }),
 ];
 
 module.exports = {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `usePreviewPath` value in redirect object to keep the site preview path generated by the platform appended to the redirect

## security considerations
None
