### PR TITLE
feat: Only allow GET, HEAD requests

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -80,6 +80,11 @@ http {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Server "Cloud.gov Pages" always;
     add_header X-Robots-Tag $robot_header always;
+    add_header Access-Control-Allow-Methods "GET, HEAD" always;
+
+    if ($request_method !~ ^(GET|HEAD)$) {
+      return 405;
+    }
 
     if ($request_uri ~ "^/((site|preview|demo))/(([^/]+))/(([^/]+))(?<remaining>(.*))$" ) {
         set  $remaining_path  $remaining;

--- a/test/main.js
+++ b/test/main.js
@@ -113,6 +113,58 @@ describe('Health check', () => {
   });
 });
 
+describe('Unallowed HTTP Methods', () => {
+  const host = 'foobar.app.cloud.gov';
+
+  it('with the DELETE method', () => {
+    return request
+      .delete(defaultPrefixPath('/bucket.html'))
+      .set('Host', host)
+      .expectStandardHeaders()
+      .expect(405);
+  });
+
+  it('with the OPTIONS method', () => {
+    return request
+      .options(defaultPrefixPath('/bucket.html'))
+      .set('Host', host)
+      .expectStandardHeaders()
+      .expect(405);
+  });
+
+  it('with the PATCH method', () => {
+    return request
+      .patch(defaultPrefixPath('/bucket.html'))
+      .set('Host', host)
+      .expectStandardHeaders()
+      .expect(405);
+  });
+
+  it('with the POST method', () => {
+    return request
+      .post(defaultPrefixPath('/bucket.html'))
+      .set('Host', host)
+      .expectStandardHeaders()
+      .expect(405);
+  });
+
+  it('with the PUT method', () => {
+    return request
+      .put(defaultPrefixPath('/bucket.html'))
+      .set('Host', host)
+      .expectStandardHeaders()
+      .expect(405);
+  });
+
+  it('with the TRACE method', () => {
+    return request
+      .trace(defaultPrefixPath('/bucket.html'))
+      .set('Host', host)
+      .expectStandardHeaders()
+      .expect(405);
+  });
+});
+
 describe('For non-`pages-proxy-staging` hosts', () => {
   const host = 'foobar.app.cloud.gov';
 


### PR DESCRIPTION
Closes #187 

## Changes proposed in this pull request:
- Add header `Access-Control-Allow-Methods "GET, HEAD"`
- Return 405 Method Not Allowed response when trying HTTP methods that are not `GET` or `HEAD`

## security considerations
Adds additional restrictions to the methods allow against the proxy.
