### PR TITLE
chore: Update app stack to cflinuxfs4

### DIFF
--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -8,6 +8,7 @@ env-cf: &env-cf
   CF_PASSWORD: ((production-cf-password))
   CF_ORG: gsa-18f-federalist
   CF_SPACE: production
+  CF_STACK: cflinuxfs4
 
 node-image: &node-image
   platform: linux

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -8,6 +8,7 @@ env-cf: &env-cf
   CF_PASSWORD: ((((deploy-env))-cf-password))
   CF_ORG: gsa-18f-federalist
   CF_SPACE: ((deploy-env))
+  CF_STACK: cflinuxfs4
 
 node-image: &node-image
   platform: linux

--- a/ci/tasks/deploy.sh
+++ b/ci/tasks/deploy.sh
@@ -7,4 +7,7 @@ cf auth
 
 cf t -o $CF_ORG -s $CF_SPACE
 
-cf push $CF_APP_NAME -f $CF_MANIFEST --strategy rolling --vars-file $CF_VARS_FILE
+cf push $CF_APP_NAME -f $CF_MANIFEST \
+  --strategy rolling \
+  --vars-file $CF_VARS_FILE \
+  --stack cflinuxfs4

--- a/ci/tasks/deploy.sh
+++ b/ci/tasks/deploy.sh
@@ -10,4 +10,4 @@ cf t -o $CF_ORG -s $CF_SPACE
 cf push $CF_APP_NAME -f $CF_MANIFEST \
   --strategy rolling \
   --vars-file $CF_VARS_FILE \
-  --stack cflinuxfs4
+  --stack $CF_STACK


### PR DESCRIPTION
Apart of https://github.com/cloud-gov/pages-core/issues/4054

## Changes proposed in this pull request:
- Explicitly set stack via the `--stack` flag in `cf push`
- Updates stack to run on cflinuxfs4 via `CF_STACK` param

## security considerations
Updates app to run on the latest base image: cflinuxfs4 stack (Ubuntu Jammy)