### PR TITLE
Update resource types to use hardened images

### DIFF
--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -307,9 +307,13 @@ resource_types:
       repository: pix4d/cogito
 
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
   - name: pull-request
     type: docker-image

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -238,9 +238,13 @@ resources:
 
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
   - name: pull-request
     type: docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -310,9 +310,13 @@ resource_types:
       repository: pix4d/cogito
 
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
   - name: pull-request
     type: docker-image


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update pipelines to use our current hardened images

## security considerations
Removes slack-notification-resource and replaces with hardened image