### PR TITLE
chore(ci): Rework staging and prod CI task topology and add .cz.json config

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,0 +1,47 @@
+{
+  "commitizen": {
+    "name": "cz_customize",
+    "version_scheme": "semver",
+    "version_provider": "npm",
+    "update_changelog_on_bump": true,
+    "major_version_zero": false,
+    "bump_message": "chore: release $new_version",
+    "gpg_sign": true,
+    "changelog_incremental": true,
+    "customize": {
+      "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+      "example": "feat: this feature enable customize through config file",
+      "schema": "<type>: <body>",
+      "schema_pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w \\-'])+([\\s\\S]*)",
+      "bump_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
+      "bump_map": {
+          ".+!": "MAJOR",
+          "BREAKING CHANGE": "MAJOR",
+          "feat": "MINOR",
+          "fix": "PATCH",
+          "chore": "PATCH",
+          "docs": "PATCH",
+          "perf": "PATCH",
+          "refactor": "PATCH",
+          "revert": "MINOR",
+          "style": "PATCH",
+          "test": "PATCH"
+      },
+      "change_type_order": ["Breaking Changes", "Added", "Fixed", "Performance", "Reverted", "Maintenance", "Documentation"],
+      "commit_parser": "^((?P<change_type>chore|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?",
+      "changelog_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
+      "change_type_map": {
+        "BREAKING CHANGE": "Breaking Changes",
+        "chore": "Maintenance",
+        "docs": "Documentation",
+        "feat": "Added",
+        "fix": "Fixed",
+        "perf": "Performance",
+        "refactor": "Maintenance",
+        "revert": "Reverted",
+        "style": "Maintenance",
+        "test": "Maintenance"
+      }
+    }
+  }
+}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -29,17 +29,6 @@ jobs:
         instance_vars:
           deploy-env: ((deploy-env))
 
-  #@ if/end env == 'staging':
-  - name: update-release-branch
-    plan:
-      - get: src
-        trigger: true
-      - get: general-task
-      - get: pipeline-tasks
-      - task: update-release-branch
-        image: general-task
-        file: pipeline-tasks/tasks/update-release-branch.yml
-
   - name: test-and-deploy
     plan:
       - get: src
@@ -125,15 +114,29 @@ jobs:
           _: #@ template.replace(data.values.env_cf)
           CF_APP_NAME: pages-proxy-((deploy-env))
 
+  #@ if/end env == 'staging':
+  - name: update-release-branch
+    passed:
+      - set-pipeline
+      - test-and-deploy
+    plan:
+      - get: src
+        trigger: true
+      - get: general-task
+      - get: pipeline-tasks
+      - task: update-release-branch
+        image: general-task
+        file: pipeline-tasks/tasks/update-release-branch.yml
+
   #@ if/end env == 'production':
   - name: release
+    passed:
+      - set-pipeline
+      - test-and-deploy
     plan:
       - get: src
         params:
-          #@ if/end env != 'dev':
           depth: 1
-          #@ if/end env == 'dev':
-          integration_tool: checkout
         trigger: true
         passed: [test-and-deploy]
       -  #@ template.replace(data.values.release_steps)


### PR DESCRIPTION
## Changes proposed in this pull request:
- Rework CI task topology for staging and prod pipelines
- Add commitizen's `.cz.json` config for releases

## security considerations
None
