### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+## 1.0.1 (2024-07-10)
+
+### Fixed
+
+- **ci**: Set src passed a correct level for release tasks
+
+### Maintenance
+
+- **ci**: Rework staging and prod CI task topology and add .cz.json config
+- Update node.js dependencies braces and fill-range
+- **ci**: pull full repo for release
+
+## 1.0.0 (2024-07-10)
+
+### Added
+
+- Add dev deployment env for PRs to staging
+- Switch to using harden container fof cf-image
+- Only allow GET, HEAD requests
+- Add usePreviewPath option on redirects to keep site preview path on redirect
+- Add build redirects to federalist proxy deploy
+- add support for empty array of redirects
+- Test and build redirects
+- Add redirects utils
+
+### Fixed
+
+- Added encoded values check regex
+- CI pipeline has working build-redirects task
+- test:integration to include redirects
+
+### Maintenance
+
+- **ci**: use boot task for multiple env deploy
+- use pipeline tasks
+- use hardened nginx image
+- container hardening
+- **ci**: Switch to general-task and registry-image for CI jobs
+- Partialize CI tests and use hardened git resource
+- Update README.md
+- Update CI pipelines to hardened resources
+- Update app stack to cflinuxfs4
+- update test env to Node 16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pages-proxy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pages-proxy",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "CC0-1.0",
       "dependencies": {
         "aws-sdk": "^2.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pages-proxy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 1.0.1
tag to create: 1.0.1
increment detected: PATCH

## 1.0.1 (2024-07-10)

### Fixed

- **ci**: Set src passed a correct level for release tasks

### Maintenance

- **ci**: Rework staging and prod CI task topology and add .cz.json config
- Update node.js dependencies braces and fill-range
- **ci**: pull full repo for release

## 1.0.0 (2024-07-10)

### Added

- Add dev deployment env for PRs to staging
- Switch to using harden container fof cf-image
- Only allow GET, HEAD requests
- Add usePreviewPath option on redirects to keep site preview path on redirect
- Add build redirects to federalist proxy deploy
- add support for empty array of redirects
- Test and build redirects
- Add redirects utils

### Fixed

- Added encoded values check regex
- CI pipeline has working build-redirects task
- test:integration to include redirects

### Maintenance

- **ci**: use boot task for multiple env deploy
- use pipeline tasks
- use hardened nginx image
- container hardening
- **ci**: Switch to general-task and registry-image for CI jobs
- Partialize CI tests and use hardened git resource
- Update README.md
- Update CI pipelines to hardened resources
- Update app stack to cflinuxfs4
- update test env to Node 16
## security considerations
Noted in individual PRs
