### PR TITLE
chore: Set x-amz-if-match-last-modified-time to empty

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -50,6 +50,7 @@ http {
   proxy_set_header If-Range "";
   proxy_set_header x-amz-expected-bucket-owner "";
   proxy_set_header x-amz-security-token "";
+  proxy_set_header x-amz-if-match-last-modified-time "";
 
   map_hash_max_size 64;
   map_hash_bucket_size 256;


### PR DESCRIPTION
## Changes proposed in this pull request:
- Set `x-amz-if-match-last-modified-time` to an empty string

## security considerations
Sets the ` x-amz-if-match-last-modified-time` header to overwrite any requests values if a cache poison is attempted.