### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.1 (2025-10-06)
+
+### Fixed
+
+- Return 404 when encoded forward slashes attempt redirect
+
+### Maintenance
+
+- Add CODEOWNERS
+
 ## 1.1.0 (2025-09-30)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pages-proxy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pages-proxy",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "CC0-1.0",
       "dependencies": {
         "aws-sdk": "^2.1045.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pages-proxy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :robot: This is an automated release PR

chore: release 1.1.1
tag to create: 1.1.1
increment detected: PATCH

## 1.1.1 (2025-10-06)

### Fixed

- Return 404 when encoded forward slashes attempt redirect

### Maintenance

- Add CODEOWNERS
## security considerations
Noted in individual PRs
