### PR TITLE
fix: Return 404 when encoded forward slashes attempt redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -125,6 +125,16 @@ http {
          error_page 404 403 =404 @notfound;
       }
 
+      # Match paths with encoded forward slashes at site root or after
+      location ~ ^/[^/]+/[^/]+/[^/]+/.*%2[Ff].* {
+         error_page 404 403 =404 @notfound;
+      }
+
+      # Match paths with double-encoded forward slashes at site root or after
+      location ~ ^/[^/]+/[^/]+/[^/]+/.*%252[Ff].* {
+         error_page 404 403 =404 @notfound;
+      }
+
       # Handle anything else with 404
       error_page 404 403 =404 @notfound;
     }
@@ -155,6 +165,16 @@ http {
       }
 
       location ~ ^/[^/]+/[^/]+/[^/]+/.*%255C.* {
+        rewrite ^(.*)$ @notfound;
+      }
+
+      # Match paths with encoded forward slashes at site root or after
+      location ~ ^/[^/]+/[^/]+/[^/]+/.*%2[Ff].* {
+        rewrite ^(.*)$ @notfound;
+      }
+
+      # Match paths with double-encoded forward slashes at site root or after
+      location ~ ^/[^/]+/[^/]+/[^/]+/.*%252[Ff].* {
         rewrite ^(.*)$ @notfound;
       }
 

--- a/test/main.js
+++ b/test/main.js
@@ -313,8 +313,13 @@ function pathSpecs(host, prefixPathFn) {
 
         describe('for potential open redirects', () => {
           it('returns a 404', () => {
-            const path = prefixPathFn(encodeURI('/\\\\example.com/%2e%2e%2f')); // /%5C%5Cexample.com/%252e%252e%252f
+            const path = prefixPathFn(encodeURI('/\\example.com/%2e%2e%2f')); // /%5C%5Cexample.com/%252e%252e%252f
 
+            return makeRequest(path, host, [[404]]);
+          });
+
+          it('returns a 404 when using double encoded forward slashes', () => {
+            const path = prefixPathFn('/%252F%252Fexample.com/%2e%2e%2f');
             return makeRequest(path, host, [[404]]);
           });
         });
@@ -332,7 +337,7 @@ function pathSpecs(host, prefixPathFn) {
 
         describe('for potential open redirects', () => {
           it('returns a 404 when using backslashes', () => {
-            const path = prefixPathFn(encodeURI('/\\\\example.com/%2e%2e%2f')); // /%5C%5Cexample.com/%252e%252e%252f
+            const path = prefixPathFn(encodeURI('/\\example.com/%2e%2e%2f')); // /%5C%5Cexample.com/%252e%252e%252f
 
             return makeCloudfrontRequest(path, host, [[404]]);
           });
@@ -345,6 +350,11 @@ function pathSpecs(host, prefixPathFn) {
 
           it('returns a 404 when using double encoded backslashes', () => {
             const path = prefixPathFn('/%255C%255Cexample.com/%2e%2e%2f');
+            return makeCloudfrontRequest(path, host, [[404]]);
+          });
+
+          it('returns a 404 when using double encoded forward slashes', () => {
+            const path = prefixPathFn('/%252F%252Fexample.com/%2e%2e%2f');
             return makeCloudfrontRequest(path, host, [[404]]);
           });
           // TODO: add back confirming test


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds check for encoded forward slashes in the url and return 404

## security considerations
Obfuscates open redirect
